### PR TITLE
fix: allow 0 value in required numeric inputs

### DIFF
--- a/src/components/ValidatedInput.jsx
+++ b/src/components/ValidatedInput.jsx
@@ -14,10 +14,14 @@ export default function ValidatedInput({
   const [error, setError] = useState('');
 
   const handleChange = (e) => {
-    const newValue = type === 'number' ? Number(e.target.value) : e.target.value;
-    
+    // Preserve the raw string value for validation so that values like "0"
+    // don't get treated as falsy when checking the required constraint.
+    const rawValue = e.target.value;
+    const newValue = type === 'number' ? Number(rawValue) : rawValue;
+
     // Validation
-    if (required && !newValue) {
+    if (required && rawValue === '') {
+      // A value is required and the input is empty
       setError('Este campo es obligatorio');
     } else if (type === 'number' && min !== undefined && newValue < min) {
       setError(`El valor mínimo es ${min}`);


### PR DESCRIPTION
## Summary
- ensure numeric inputs treat `0` as a valid required value

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689835996e14832294cf59b6bcddcd2f