### PR TITLE
refactor: integrate shadcn-style ui components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { PRESETS, retainerSuggestion } from './presets.js';
-import clsx from 'clsx';
 
 // Import components
 import RegionSelector from './components/RegionSelector';
 import DebouncedInput from './components/DebouncedInput';
 import AccessibleSelect from './components/AccessibleSelect';
 import ThemeToggle from './components/ThemeToggle';
+import { Button } from './components/ui/button';
+import { Card } from './components/ui/card';
 
 // Import hooks
 import { useRateCalculation } from './hooks/useRateCalculation';
@@ -257,7 +258,7 @@ export default function App() {
       <div className="flex-grow flex flex-col md:flex-row">
         {/* Left: Form */}
         <section className="w-full md:w-7/12 p-4">
-          <div className="card">
+          <Card>
             <div className="grid grid-cols-12 gap-3">
               {/* Region and currency selectors */}
               <RegionSelector 
@@ -471,23 +472,23 @@ export default function App() {
 
               {/* Buttons */}
               <div className="col-span-12 flex flex-wrap gap-2 mt-2">
-                <button className="btn" onClick={() => applyPreset(region)}>
+                <Button onClick={() => applyPreset(region)}>
                   Restablecer presets de la región
-                </button>
-                <button className="btn btn-secondary" onClick={() => exportJson()}>
+                </Button>
+                <Button variant="secondary" onClick={() => exportJson()}>
                   Exportar estimación (JSON)
-                </button>
-                <button className="btn btn-secondary" onClick={() => handleExportPDF()}>
+                </Button>
+                <Button variant="secondary" onClick={() => handleExportPDF()}>
                   Exportar PDF
-                </button>
+                </Button>
               </div>
             </div>
-          </div>
+          </Card>
         </section>
 
         {/* Right: Results */}
         <aside className="w-full md:w-5/12">
-          <div className="card md:sticky md:top-4">
+          <Card className="md:sticky md:top-4">
             <div className="grid grid-cols-12 gap-3">
               <div className="col-span-12">
                 <h2 className="text-lg font-bold mb-3">Resultados</h2>
@@ -567,7 +568,7 @@ export default function App() {
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
         </aside>
       </div>
 

--- a/src/components/AccessibleSelect.jsx
+++ b/src/components/AccessibleSelect.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Label } from './ui/label';
+import { Select } from './ui/select';
 
 export default function AccessibleSelect({
   label,
@@ -9,14 +11,12 @@ export default function AccessibleSelect({
   helpText,
 }) {
   return (
-    <div className="form-group">
-      <label htmlFor={id} className="text-xs muted">
-        {label}
-      </label>
-      <select
+    <div className="space-y-1">
+      <Label htmlFor={id}>{label}</Label>
+      <Select
         id={id}
         value={value}
-        onChange={onChange}
+        onChange={(e) => onChange(e.target.value)}
         aria-describedby={helpText ? `${id}-help` : undefined}
       >
         {options.map((option) => (
@@ -24,11 +24,11 @@ export default function AccessibleSelect({
             {option.label}
           </option>
         ))}
-      </select>
+      </Select>
       {helpText && (
-        <div id={`${id}-help`} className="muted small mt-1">
+        <p id={`${id}-help`} className="text-xs text-[var(--muted)]">
           {helpText}
-        </div>
+        </p>
       )}
     </div>
   );

--- a/src/components/RegionSelector.jsx
+++ b/src/components/RegionSelector.jsx
@@ -1,28 +1,36 @@
 import React from 'react';
+import AccessibleSelect from './AccessibleSelect';
 
 export default function RegionSelector({ region, setRegion, currency, setCurrency }) {
   return (
     <>
       <div className="col-span-12 md:col-span-6">
-        <label className="text-xs muted">Región (preset)</label>
-        <select
+        <AccessibleSelect
+          label="Región (preset)"
+          id="region"
           value={region}
-          onChange={(e) => setRegion(e.target.value)}
-        >
-          <option value="LATAM">Latinoamérica (preset)</option>
-          <option value="EU_WEST">Europa Occidental (preset)</option>
-          <option value="EU_EAST">Europa del Este (preset)</option>
-          <option value="USA">USA / Canadá (preset)</option>
-        </select>
+          onChange={setRegion}
+          options={[
+            { value: 'LATAM', label: 'Latinoamérica (preset)' },
+            { value: 'EU_WEST', label: 'Europa Occidental (preset)' },
+            { value: 'EU_EAST', label: 'Europa del Este (preset)' },
+            { value: 'USA', label: 'USA / Canadá (preset)' }
+          ]}
+        />
       </div>
       <div className="col-span-12 md:col-span-6">
-        <label className="text-xs muted">Moneda (solo visual)</label>
-        <select value={currency} onChange={(e) => setCurrency(e.target.value)}>
-          <option value="USD">USD ($)</option>
-          <option value="EUR">EUR (€)</option>
-          <option value="ARS">ARS ($)</option>
-          <option value="GBP">GBP (£)</option>
-        </select>
+        <AccessibleSelect
+          label="Moneda (solo visual)"
+          id="currency"
+          value={currency}
+          onChange={setCurrency}
+          options={[
+            { value: 'USD', label: 'USD ($)' },
+            { value: 'EUR', label: 'EUR (€)' },
+            { value: 'ARS', label: 'ARS ($)' },
+            { value: 'GBP', label: 'GBP (£)' }
+          ]}
+        />
       </div>
     </>
   );

--- a/src/components/ValidatedInput.jsx
+++ b/src/components/ValidatedInput.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { Label } from './ui/label';
+import { Input } from './ui/input';
 
 export default function ValidatedInput({
   label,
@@ -35,19 +37,19 @@ export default function ValidatedInput({
   };
 
   return (
-    <div className="input-group">
-      <label className="text-xs muted">{label}</label>
-      <input
+    <div className="space-y-1">
+      <Label>{label}</Label>
+      <Input
         type={type}
         min={min}
         max={max}
         step={step}
         value={value}
         onChange={handleChange}
-        className={error ? 'error' : ''}
+        className={error ? 'border-[var(--bad)]' : ''}
       />
-      {error && <div className="error-text text-xs">{error}</div>}
-      {helpText && !error && <div className="muted small mt-1">{helpText}</div>}
+      {error && <p className="text-xs text-[var(--bad)]">{error}</p>}
+      {helpText && !error && <p className="text-xs text-[var(--muted)]">{helpText}</p>}
     </div>
   );
 }

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-[var(--brand)] text-white hover:bg-[var(--brand)]/90",
+        secondary: "bg-[#0b0e20] text-[var(--text)] border border-[var(--border)] hover:bg-[#0b0e20]/80",
+        outline: "border border-[var(--border)] text-[var(--text)] hover:bg-[var(--panel)]",
+        ghost: "hover:bg-[var(--panel)] text-[var(--text)]",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 px-3 rounded-md",
+        lg: "h-11 px-8 rounded-md",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+const Button = React.forwardRef(({ className, variant, size, ...props }, ref) => {
+  return (
+    <button
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4 text-[var(--text)]", className)}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = ({ className, ...props }) => (
+  <div className={cn("mb-3", className)} {...props} />
+);
+
+const CardTitle = ({ className, ...props }) => (
+  <h2 className={cn("text-lg font-bold", className)} {...props} />
+);
+
+const CardContent = ({ className, ...props }) => (
+  <div className={cn("", className)} {...props} />
+);
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+const Input = React.forwardRef(({ className, type = "text", ...props }, ref) => (
+  <input
+    type={type}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[#0b0e20] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/label.jsx
+++ b/src/components/ui/label.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn("text-xs font-medium text-[var(--muted)]", className)}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+const Select = React.forwardRef(({ className, children, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[#0b0e20] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </select>
+));
+Select.displayName = "Select";
+
+export { Select };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add reusable Shadcn-style button, input, select, label, and card components
- refactor form inputs and selectors to use new components for better UX
- update main app layout with Card containers and Button actions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689836c479fc8322a56bbc41eefc9816