### PR TITLE
fix: honor feature flag env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ npm install
 npm run dev
 ```
 
+### Environment Variables
+
+Feature flags can be configured through Vite environment variables:
+
+- `VITE_ENABLE_THEME_TOGGLE` (default `true`, set to `false` to disable)
+- `VITE_ENABLE_EXPORT` (default `true`, set to `false` to disable)
+- `VITE_ENABLE_SAVED_PRESETS` (default `false`, set to `true` to enable)
+
+Create a `.env` file or export the variables in your shell before running the app.
+
 ### Building for Production
 
 ```bash

--- a/src/config.js
+++ b/src/config.js
@@ -6,10 +6,13 @@ export const config = {
   defaultCurrency: import.meta.env.VITE_DEFAULT_CURRENCY || 'USD',
   // Default region
   defaultRegion: import.meta.env.VITE_DEFAULT_REGION || 'LATAM',
-  // Feature flags
+  // Feature flags controlled via environment variables
   features: {
-    enableThemeToggle: import.meta.env.VITE_ENABLE_THEME_TOGGLE === 'true' || true,
-    enableExport: import.meta.env.VITE_ENABLE_EXPORT === 'true' || true,
-    enableSavedPresets: import.meta.env.VITE_ENABLE_SAVED_PRESETS === 'true' || false,
+    // Enabled by default; set VITE_ENABLE_THEME_TOGGLE="false" to disable
+    enableThemeToggle: import.meta.env.VITE_ENABLE_THEME_TOGGLE !== 'false',
+    // Enabled by default; set VITE_ENABLE_EXPORT="false" to disable
+    enableExport: import.meta.env.VITE_ENABLE_EXPORT !== 'false',
+    // Disabled by default; set VITE_ENABLE_SAVED_PRESETS="true" to enable
+    enableSavedPresets: import.meta.env.VITE_ENABLE_SAVED_PRESETS === 'true',
   },
 };


### PR DESCRIPTION
## Summary
- honor VITE_* feature flags by removing always-on fallbacks
- document environment variables for toggling features

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689838fe80448322b7def2e01dd9732d