### PR TITLE
fix: honor feature flags and add testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ npm install
 npm run dev
 ```
 
+### Environment Variables
+
+Feature flags can be configured through Vite environment variables:
+
+- `VITE_ENABLE_THEME_TOGGLE` (default `true`, set to `false` to disable)
+- `VITE_ENABLE_EXPORT` (default `true`, set to `false` to disable)
+- `VITE_ENABLE_SAVED_PRESETS` (default `false`, set to `true` to enable)
+
+Create a `.env` file or export the variables in your shell before running the app.
+
 ### Building for Production
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.2",
@@ -24,6 +25,10 @@
     "postcss": "^8.4.21",
     "tailwindcss": "^3.4.1",
     "vite": "^4.4.2",
-    "vite-plugin-pwa": "^1.0.2"
+    "vite-plugin-pwa": "^1.0.2",
+    "vitest": "^0.34.4",
+    "jsdom": "^22.1.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.5"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -6,10 +6,13 @@ export const config = {
   defaultCurrency: import.meta.env.VITE_DEFAULT_CURRENCY || 'USD',
   // Default region
   defaultRegion: import.meta.env.VITE_DEFAULT_REGION || 'LATAM',
-  // Feature flags
+  // Feature flags controlled via environment variables
   features: {
-    enableThemeToggle: import.meta.env.VITE_ENABLE_THEME_TOGGLE === 'true' || true,
-    enableExport: import.meta.env.VITE_ENABLE_EXPORT === 'true' || true,
-    enableSavedPresets: import.meta.env.VITE_ENABLE_SAVED_PRESETS === 'true' || false,
+    // Enabled by default; set VITE_ENABLE_THEME_TOGGLE="false" to disable
+    enableThemeToggle: import.meta.env.VITE_ENABLE_THEME_TOGGLE !== 'false',
+    // Enabled by default; set VITE_ENABLE_EXPORT="false" to disable
+    enableExport: import.meta.env.VITE_ENABLE_EXPORT !== 'false',
+    // Disabled by default; set VITE_ENABLE_SAVED_PRESETS="true" to enable
+    enableSavedPresets: import.meta.env.VITE_ENABLE_SAVED_PRESETS === 'true',
   },
 };

--- a/src/hooks/useRateCalculation.test.js
+++ b/src/hooks/useRateCalculation.test.js
@@ -1,4 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
 import { useRateCalculation } from './useRateCalculation';
 
 describe('useRateCalculation', () => {

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -29,4 +29,8 @@ export default defineConfig({
     }),
   ],
   base: '/calculator-per-hour/',
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.js',
+  },
 })


### PR DESCRIPTION
## Summary
- honor VITE_* feature flags by removing always-on fallbacks
- document environment variables for toggling features
- set up Vitest and Testing Library for unit tests
- migrate rate calculation hook test to Vitest

## Testing
- `npm install -D vitest jsdom @testing-library/react @testing-library/jest-dom` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689838fe80448322b7def2e01dd9732d