### PR TITLE
fix: correct Licenses spelling in presets

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -10,7 +10,7 @@ export const PRESETS = {
   LATAM: {
     uiIncome: 60000, // Suggested annual income (USD) for a senior UI designer
     uxrIncome: 60000, // Suggested annual income (USD) for a senior researcher
-    overhead: 10000, // Licences, equipment, marketing per person
+    overhead: 10000, // Licenses, equipment, marketing per person
     weeks: 48,
     hoursPerWeek: 40,
     billablePct: 50, // ≈ 960–1000 h/year (taking into account non‑billable work)


### PR DESCRIPTION
## Summary
- fix spelling in preset overhead comment

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68983f4ed7f4832297a9d1488686c1c2