### PR TITLE
feat: refresh theme with natural palette

### DIFF
--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-[var(--brand)] text-white hover:bg-[var(--brand)]/90",
-        secondary: "bg-[#0b0e20] text-[var(--text)] border border-[var(--border)] hover:bg-[#0b0e20]/80",
+        secondary: "bg-[var(--panel)] text-[var(--text)] border border-[var(--border)] hover:bg-[color:rgba(255,255,255,0.9)]",
         outline: "border border-[var(--border)] text-[var(--text)] hover:bg-[var(--panel)]",
         ghost: "hover:bg-[var(--panel)] text-[var(--text)]",
       },

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -4,7 +4,10 @@ import { cn } from "../../lib/utils";
 const Card = React.forwardRef(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4 text-[var(--text)]", className)}
+    className={cn(
+      "rounded-lg border border-[var(--border)] bg-[var(--panel)] backdrop-blur-sm p-4 text-[var(--text)]",
+      className
+    )}
     {...props}
   />
 ));

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -5,7 +5,7 @@ const Input = React.forwardRef(({ className, type = "text", ...props }, ref) => 
   <input
     type={type}
     className={cn(
-      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[#0b0e20] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     ref={ref}

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -5,7 +5,7 @@ const Select = React.forwardRef(({ className, children, ...props }, ref) => (
   <select
     ref={ref}
     className={cn(
-      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[#0b0e20] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]",
+      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]",
       className
     )}
     {...props}

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,31 +1,32 @@
 import { useState, useEffect } from 'react';
 
 const lightTheme = {
-  '--bg': '#f5f7fa',
-  '--panel': '#ffffff',
-  '--muted': '#6b7280',
-  '--text': '#1f2937',
-  '--brand': '#7c5cff',
-  '--good': '#2fd17a',
-  '--bad': '#ff7d7d',
-  '--warn': '#ffcd57',
-  '--border': '#e5e7eb',
+  '--bg': '#f1f5f2',
+  '--panel': 'rgba(255,255,255,0.8)',
+  '--muted': '#6b705c',
+  '--text': '#1a1d1a',
+  '--brand': '#4f772d',
+  '--good': '#588157',
+  '--bad': '#bc4749',
+  '--warn': '#e9c46a',
+  '--border': '#b7b7a4',
 };
 
 const darkTheme = {
-  '--bg': '#0f1222',
-  '--panel': '#171a2e',
-  '--muted': '#8b91b4',
-  '--text': '#e7e9f7',
-  '--brand': '#7c5cff',
-  '--good': '#2fd17a',
-  '--bad': '#ff7d7d',
-  '--warn': '#ffcd57',
-  '--border': '#23264a',
+  '--bg': '#1b1d1a',
+  '--panel': 'rgba(40,44,38,0.8)',
+  '--muted': '#a3a69b',
+  '--text': '#e7e9e3',
+  '--brand': '#4f772d',
+  '--good': '#588157',
+  '--bad': '#bc4749',
+  '--warn': '#e9c46a',
+  '--border': '#3f4430',
 };
 
 export function useTheme() {
-  const [isDark, setIsDark] = useState(true);
+  // Use the lighter palette by default
+  const [isDark, setIsDark] = useState(false);
 
   useEffect(() => {
     // Check for user preference

--- a/src/index.css
+++ b/src/index.css
@@ -2,20 +2,27 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Define CSS variables to mirror the original dark theme used in the
-   HTML version of the calculator. These variables will be used by
-   our components to style backgrounds, borders and text colours.
-*/
+/* Define CSS variables for a lighter, nature inspired palette. These
+   variables power the Shadcn components and keep colours consistent
+   across the app. Greens and olives give the calculator a friendlier
+   feel compared to the previous dark theme. */
 :root {
-  --bg: #0f1222;
-  --panel: #171a2e;
-  --muted: #8b91b4;
-  --text: #e7e9f7;
-  --brand: #7c5cff;
-  --good: #2fd17a;
-  --bad: #ff7d7d;
-  --warn: #ffcd57;
-  --border: #23264a;
+  /* soft green background */
+  --bg: #f1f5f2;
+  /* translucent panel for a subtle glass effect */
+  --panel: rgba(255, 255, 255, 0.8);
+  /* muted olive for secondary text */
+  --muted: #6b705c;
+  /* main text colour */
+  --text: #1a1d1a;
+  /* brand accent */
+  --brand: #4f772d;
+  /* semantic colours */
+  --good: #588157;
+  --bad: #bc4749;
+  --warn: #e9c46a;
+  /* light olive border */
+  --border: #b7b7a4;
 }
 
 * {
@@ -34,6 +41,7 @@ body {
    reused in JSX via className to keep the markup concise. */
 .card {
   background: var(--panel);
+  backdrop-filter: blur(6px);
   border: 1px solid var(--border);
   border-radius: 0.875rem; /* 14px */
   padding: 1rem; /* 16px */
@@ -42,7 +50,8 @@ body {
   padding: 0.875rem; /* 14px */
   border: 1px dashed var(--border);
   border-radius: 0.75rem; /* 12px */
-  background: rgba(124, 92, 255, 0.07);
+  /* faint brand tint */
+  background: rgba(79, 119, 45, 0.07);
 }
 .btn {
   background: var(--brand);
@@ -54,7 +63,7 @@ body {
   text-align: center;
 }
 .btn-secondary {
-  background: #0b0e20;
+  background: var(--panel);
   color: var(--text);
   border: 1px solid var(--border);
 }
@@ -67,7 +76,7 @@ body {
 .pill {
   display: inline-block;
   padding: 0.375rem 0.625rem; /* 6px 10px */
-  background: #0b0e20;
+  background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 9999px;
   font-size: 0.75rem;
@@ -84,7 +93,7 @@ select {
   padding: 0.625rem 0.75rem; /* 10px 12px */
   border-radius: 0.625rem; /* 10px */
   border: 1px solid var(--border);
-  background: #0b0e20;
+  background: var(--panel);
   color: var(--text);
   outline: none;
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
         name: 'Conversor de tarifas',
         short_name: 'Tarifas',
         description: 'Calculadora de tarifas para UI y UX Research',
-        theme_color: '#7c5cff',
+        theme_color: '#4f772d',
         icons: [
           {
             src: 'pwa-192x192.png',


### PR DESCRIPTION
## Summary
- restyle app with a green and olive palette and subtle glass panels
- update shadcn components to use the new theme colours
- switch theme toggler and manifest to the new branding

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68984757700c83229fa1152696bcb088