### PR TITLE
fix: use master branch for deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Vite app to GitHub Pages
 
 on:
   push:
-    branches: [ main ]        # se ejecuta en cada push a la rama principal
+    branches: [ master ]        # se ejecuta en cada push a la rama principal
   workflow_dispatch:          # permite ejecutarlo manualmente
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger deploy workflow on master branch instead of main

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68984d42a6548322ac59f5dedb3dde73