### PR TITLE
docs: add PWA cache update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ The deployed application will be available at: `https://davecelot.github.io/calc
 
 The application is configured as a Progressive Web App (PWA) using `vite-plugin-pwa`, allowing users to install it on their devices and use it offline.
 
+### Cache updates
+
+Although `vite-plugin-pwa` is set to `registerType: 'autoUpdate'`, some browsers may continue serving cached assets after a new deployment. Consider bumping the manifest version or renaming assets to force the browser to fetch the latest files. Users may need to perform a hard refresh (`Ctrl+F5`) or clear the PWA cache to load the most recent version.
+
 ## Technologies Used
 
 - React 18


### PR DESCRIPTION
## Summary
- document that browsers may keep cached PWA assets despite autoUpdate
- instruct users to bump manifest version or rename assets and do a hard refresh

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68984d704b7883228ef92f910b0f3d57