### PR TITLE
Fix select handlers for adjuster and engagement sections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -255,15 +255,13 @@ export default function App() {
   ];
 
   // Validate select changes
-  function handleClientTypeChange(e) {
-    const value = e.target.value;
+  function handleClientTypeChange(value) {
     if (CLIENT_MULT[value] !== undefined) {
       setClientType(value);
     }
   }
 
-  function handleComplexityChange(e) {
-    const value = e.target.value;
+  function handleComplexityChange(value) {
     if (COMPLEXITY_MULT[value] !== undefined) {
       setComplexity(value);
     }
@@ -464,7 +462,7 @@ export default function App() {
                   id="engagement"
                   label="Tipo"
                   value={engagement}
-                  onChange={(e) => setEngagement(e.target.value)}
+                  onChange={setEngagement}
                   options={engagementOptions}
                 />
               </div>


### PR DESCRIPTION
## Summary
- Accept direct select values in client type and complexity handlers
- Simplify engagement model select handler

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689850478fbc832298c1bd2e6e99f3e6