### PR TITLE
feat: add brand adapters for shadcn ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,11 @@ npx shadcn@latest init
 # install common components
 npx shadcn@latest add button input label card select slider tooltip dialog accordion
 ```
+
+## How to add more Shadcn components
+
+To scaffold additional components from the library run:
+
+```bash
+npx shadcn@latest add <component>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.2.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^1.2.1",
@@ -2160,6 +2161,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -2554,6 +2564,525 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.2.2.tgz",
+      "integrity": "sha512-zI7McXr8fNaSrUY9mZe4x/HC0jTLY9fWNhO1oLWYMQGDXuV4UCivIGTxwioSzO0ZCYX9iSLyWmAh/1TOmX3Cnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.4",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.3",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.2",
+        "@radix-ui/react-portal": "1.0.3",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-arrow": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
+      "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-collection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.4.tgz",
+      "integrity": "sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.3.tgz",
+      "integrity": "sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-popper": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.2.tgz",
+      "integrity": "sha512-1CnGGfFi/bbqtJZZ0P/NQY20xdG3E0LALJaLUEoKwPLwl6PPPfbeiCqMVQnhoFRAxjJj4RpBRJzDmUgsex2tSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-rect": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-portal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.3.tgz",
+      "integrity": "sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz",
+      "integrity": "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
+      "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
+      "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz",
+      "integrity": "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/react-remove-scroll": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -2684,6 +3213,24 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,8 @@ import RegionSelector from '@/components/RegionSelector';
 import DebouncedInput from '@/components/DebouncedInput';
 import AccessibleSelect from '@/components/AccessibleSelect';
 import ThemeToggle from '@/components/ThemeToggle';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
+import { BrandButton } from '@/components/brand/BrandButton';
+import { BrandCard } from '@/components/brand/BrandCard';
 import DevelopmentTimePanel from '@/components/DevelopmentTimePanel';
 import ModeToggle from '@/components/ModeToggle';
 import ProjectControls from '@/components/ProjectControls';
@@ -388,7 +388,7 @@ export default function App() {
               setHoursPerWeek={setHoursPerWeek}
             />
             <section>
-              <Card>
+              <BrandCard>
                 <div className="grid grid-cols-12 gap-3">
               {/* Region and currency selectors */}
               <RegionSelector
@@ -583,18 +583,18 @@ export default function App() {
 
               {/* Buttons */}
               <div className="col-span-12 flex flex-wrap gap-2 mt-2">
-                <Button onClick={() => applyPreset(region)}>
+                <BrandButton onClick={() => applyPreset(region)}>
                   Restablecer presets de la región
-                </Button>
-                <Button variant="secondary" onClick={() => exportJson()}>
+                </BrandButton>
+                <BrandButton variant="secondary" onClick={() => exportJson()}>
                   Exportar estimación (JSON)
-                </Button>
-                <Button variant="secondary" onClick={() => handleExportPDF()}>
+                </BrandButton>
+                <BrandButton variant="secondary" onClick={() => handleExportPDF()}>
                   Exportar PDF
-                </Button>
+                </BrandButton>
               </div>
               </div>
-            </Card>
+              </BrandCard>
           </section>
           {mode === 'project' && (
             <ProjectControls
@@ -612,7 +612,7 @@ export default function App() {
 
         {/* Right: Results */}
         <aside className="md:col-span-1">
-          <Card className="md:sticky md:top-4">
+          <BrandCard className="md:sticky md:top-4">
             <div className="grid grid-cols-12 gap-3">
               <div className="col-span-12">
                 <h2 className="text-lg font-bold mb-3">Resultados</h2>
@@ -737,7 +737,7 @@ export default function App() {
                 </div>
               </div>
             </div>
-          </Card>
+          </BrandCard>
           {mode === 'project' && (
             <div className="mt-4">
               <ProjectResultCard

--- a/src/components/AccessibleSelect.jsx
+++ b/src/components/AccessibleSelect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Label } from './ui/label';
-import { Select } from './ui/select';
+import { BrandSelect } from '@/components/brand/BrandSelect';
 
 export default function AccessibleSelect({
   label,
@@ -13,18 +13,21 @@ export default function AccessibleSelect({
   return (
     <div className="space-y-1">
       <Label htmlFor={id}>{label}</Label>
-      <Select
-        id={id}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        aria-describedby={helpText ? `${id}-help` : undefined}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </Select>
+      <BrandSelect value={value} onValueChange={onChange}>
+        <BrandSelect.Trigger
+          id={id}
+          aria-describedby={helpText ? `${id}-help` : undefined}
+        >
+          <BrandSelect.Value />
+        </BrandSelect.Trigger>
+        <BrandSelect.Content>
+          {options.map((option) => (
+            <BrandSelect.Item key={option.value} value={option.value}>
+              {option.label}
+            </BrandSelect.Item>
+          ))}
+        </BrandSelect.Content>
+      </BrandSelect>
       {helpText && (
         <p id={`${id}-help`} className="text-xs text-[var(--muted)]">
           {helpText}

--- a/src/components/DevelopmentTimePanel.jsx
+++ b/src/components/DevelopmentTimePanel.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Card } from './ui/card';
+import { BrandCard } from '@/components/brand/BrandCard';
 import { Label } from './ui/label';
+import { BrandSlider } from '@/components/brand/BrandSlider';
 
 export default function DevelopmentTimePanel({ weeks, setWeeks, hoursPerWeek, setHoursPerWeek }) {
   const months = Math.round(weeks / 4);
@@ -9,7 +10,7 @@ export default function DevelopmentTimePanel({ weeks, setWeeks, hoursPerWeek, se
   const progress = (months / 12) * circumference;
 
   return (
-    <Card className="flex flex-col items-center">
+    <BrandCard className="flex flex-col items-center">
       <h2 className="text-lg font-bold mb-4">Tiempo de desarrollo</h2>
       <svg width="120" height="120" className="mb-4">
         <circle cx="60" cy="60" r={radius} stroke="var(--border)" strokeWidth="8" fill="none" />
@@ -34,8 +35,9 @@ export default function DevelopmentTimePanel({ weeks, setWeeks, hoursPerWeek, se
           {months}m
         </text>
       </svg>
-      <Label className="w-full text-center mb-1">Meses</Label>
-      <input
+      <Label htmlFor="months" className="w-full text-center mb-1">Meses</Label>
+      <BrandSlider
+        id="months"
         type="range"
         min="1"
         max="12"
@@ -44,8 +46,11 @@ export default function DevelopmentTimePanel({ weeks, setWeeks, hoursPerWeek, se
         className="w-full mb-4"
         style={{ accentColor: 'var(--brand)' }}
       />
-      <Label className="w-full text-center mb-1">Horas por semana: {hoursPerWeek}</Label>
-      <input
+      <Label htmlFor="hours-per-week" className="w-full text-center mb-1">
+        Horas por semana: {hoursPerWeek}
+      </Label>
+      <BrandSlider
+        id="hours-per-week"
         type="range"
         min="1"
         max="80"
@@ -54,6 +59,6 @@ export default function DevelopmentTimePanel({ weeks, setWeeks, hoursPerWeek, se
         className="w-full"
         style={{ accentColor: 'var(--brand)' }}
       />
-    </Card>
+    </BrandCard>
   );
 }

--- a/src/components/ProjectControls.jsx
+++ b/src/components/ProjectControls.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Card } from './ui/card';
+import { BrandCard } from '@/components/brand/BrandCard';
 import { Label } from './ui/label';
-import { Input } from './ui/input';
+import { BrandSlider } from '@/components/brand/BrandSlider';
+import { BrandSelect } from '@/components/brand/BrandSelect';
 
 /**
  * Inputs for project mode assumptions.
@@ -18,12 +19,12 @@ export default function ProjectControls({
   setRoundingStep,
 }) {
   return (
-    <Card className="p-4 mt-4">
+    <BrandCard className="p-4 mt-4">
       <h2 className="text-base font-semibold mb-3">Proyecto</h2>
       <div className="space-y-4">
         <div>
           <Label htmlFor="meses">Duración del proyecto (meses)</Label>
-          <Input
+          <BrandSlider
             id="meses"
             type="range"
             min={1}
@@ -40,7 +41,7 @@ export default function ProjectControls({
 
         <div>
           <Label htmlFor="dedicacion">Dedicación al proyecto (%)</Label>
-          <Input
+          <BrandSlider
             id="dedicacion"
             type="range"
             min={10}
@@ -57,34 +58,40 @@ export default function ProjectControls({
 
         <div>
           <Label htmlFor="buffer">Buffer/Riesgo (%)</Label>
-          <select
-            id="buffer"
-            className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--panel)] p-2 text-sm"
-            value={buffer}
-            onChange={(e) => setBuffer(parseInt(e.target.value))}
+          <BrandSelect
+            value={buffer.toString()}
+            onValueChange={(v) => setBuffer(parseInt(v))}
           >
-            {[0, 10, 15, 20, 30].map((b) => (
-              <option key={b} value={b}>
-                {b}%
-              </option>
-            ))}
-          </select>
+            <BrandSelect.Trigger id="buffer" className="mt-1 w-full">
+              <BrandSelect.Value />
+            </BrandSelect.Trigger>
+            <BrandSelect.Content>
+              {[0, 10, 15, 20, 30].map((b) => (
+                <BrandSelect.Item key={b} value={b.toString()}>
+                  {b}%
+                </BrandSelect.Item>
+              ))}
+            </BrandSelect.Content>
+          </BrandSelect>
         </div>
 
         <div>
           <Label htmlFor="round">Redondear</Label>
-          <select
-            id="round"
-            className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--panel)] p-2 text-sm"
-            value={roundingStep}
-            onChange={(e) => setRoundingStep(parseInt(e.target.value))}
+          <BrandSelect
+            value={roundingStep.toString()}
+            onValueChange={(v) => setRoundingStep(parseInt(v))}
           >
-            <option value={0}>Sin redondeo</option>
-            <option value={100}>a $100</option>
-            <option value={1000}>a $1.000</option>
-          </select>
+            <BrandSelect.Trigger id="round" className="mt-1 w-full">
+              <BrandSelect.Value />
+            </BrandSelect.Trigger>
+            <BrandSelect.Content>
+              <BrandSelect.Item value="0">Sin redondeo</BrandSelect.Item>
+              <BrandSelect.Item value="100">a $100</BrandSelect.Item>
+              <BrandSelect.Item value="1000">a $1.000</BrandSelect.Item>
+            </BrandSelect.Content>
+          </BrandSelect>
         </div>
       </div>
-    </Card>
+    </BrandCard>
   );
 }

--- a/src/components/ValidatedInput.jsx
+++ b/src/components/ValidatedInput.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useId } from 'react';
 import { Label } from './ui/label';
-import { Input } from './ui/input';
+import { BrandInput } from '@/components/brand/BrandInput';
 
 export default function ValidatedInput({
   label,
@@ -12,8 +12,11 @@ export default function ValidatedInput({
   type = 'number',
   required = false,
   helpText,
+  id,
 }) {
   const [error, setError] = useState('');
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
 
   const handleChange = (e) => {
     // Preserve the raw string value for validation so that values like "0"
@@ -38,8 +41,9 @@ export default function ValidatedInput({
 
   return (
     <div className="space-y-1">
-      <Label>{label}</Label>
-      <Input
+      <Label htmlFor={inputId}>{label}</Label>
+      <BrandInput
+        id={inputId}
         type={type}
         min={min}
         max={max}
@@ -47,9 +51,14 @@ export default function ValidatedInput({
         value={value}
         onChange={handleChange}
         className={error ? 'border-[var(--bad)]' : ''}
+        aria-describedby={helpText ? `${inputId}-help` : undefined}
       />
       {error && <p className="text-xs text-[var(--bad)]">{error}</p>}
-      {helpText && !error && <p className="text-xs text-[var(--muted)]">{helpText}</p>}
+      {helpText && !error && (
+        <p id={`${inputId}-help`} className="text-xs text-[var(--muted)]">
+          {helpText}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/brand/BrandButton.tsx
+++ b/src/components/brand/BrandButton.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const VARIANT_MAP: Record<
+  "primary" | "secondary" | "outline" | "ghost" | "destructive",
+  string
+> = {
+  primary: "btn",
+  secondary: "btn btn-secondary",
+  outline: "btn btn-secondary",
+  ghost: "",
+  destructive: "",
+};
+
+const SIZE_MAP: Record<"sm" | "md" | "lg", string> = {
+  sm: "px-3 py-1.5 text-sm",
+  md: "px-4 py-2",
+  lg: "px-5 py-2.5 text-base",
+};
+
+const UNDERLYING_VARIANT: Record<
+  "primary" | "secondary" | "outline" | "ghost" | "destructive",
+  any
+> = {
+  primary: "default",
+  secondary: "secondary",
+  outline: "outline",
+  ghost: "ghost",
+  destructive: "destructive",
+};
+
+const UNDERLYING_SIZE: Record<"sm" | "md" | "lg", any> = {
+  sm: "sm",
+  md: "default",
+  lg: "lg",
+};
+
+export interface BrandButtonProps
+  extends React.ComponentPropsWithoutRef<typeof Button> {
+  variant?: "primary" | "secondary" | "outline" | "ghost" | "destructive";
+  size?: "sm" | "md" | "lg";
+}
+
+export const BrandButton = React.forwardRef<
+  React.ElementRef<typeof Button>,
+  BrandButtonProps
+>(({ className, variant = "primary", size = "md", ...props }, ref) => {
+  return (
+    <Button
+      ref={ref}
+      variant={UNDERLYING_VARIANT[variant]}
+      size={UNDERLYING_SIZE[size]}
+      className={cn(VARIANT_MAP[variant], SIZE_MAP[size], className)}
+      {...props}
+    />
+  );
+});
+BrandButton.displayName = "BrandButton";
+
+export default BrandButton;

--- a/src/components/brand/BrandCard.tsx
+++ b/src/components/brand/BrandCard.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export const BrandCard = React.forwardRef<
+  React.ElementRef<typeof Card>,
+  React.ComponentPropsWithoutRef<typeof Card>
+>(({ className, ...props }, ref) => (
+  <Card ref={ref} className={cn("", className)} {...props} />
+));
+BrandCard.displayName = "BrandCard";
+
+export const BrandCardHeader: React.FC<
+  React.ComponentPropsWithoutRef<typeof CardHeader>
+> = ({ className, ...props }) => (
+  <CardHeader className={cn("", className)} {...props} />
+);
+
+export const BrandCardContent: React.FC<
+  React.ComponentPropsWithoutRef<typeof CardContent>
+> = ({ className, ...props }) => (
+  <CardContent className={cn("", className)} {...props} />
+);
+
+export const BrandCardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("pt-4", className)} {...props} />
+));
+BrandCardFooter.displayName = "BrandCardFooter";
+
+export default BrandCard;

--- a/src/components/brand/BrandInput.tsx
+++ b/src/components/brand/BrandInput.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface BrandInputProps
+  extends React.ComponentPropsWithoutRef<typeof Input> {}
+
+export const BrandInput = React.forwardRef<
+  React.ElementRef<typeof Input>,
+  BrandInputProps
+>(({ className, ...props }, ref) => (
+  <Input
+    ref={ref}
+    className={cn("px-3 py-2 rounded-md", className)}
+    {...props}
+  />
+));
+BrandInput.displayName = "BrandInput";
+
+export default BrandInput;

--- a/src/components/brand/BrandSelect.tsx
+++ b/src/components/brand/BrandSelect.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+const BrandSelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectTrigger>,
+  React.ComponentPropsWithoutRef<typeof SelectTrigger>
+>(({ className, ...props }, ref) => (
+  <SelectTrigger ref={ref} className={cn(className)} {...props} />
+));
+BrandSelectTrigger.displayName = "BrandSelectTrigger";
+
+const BrandSelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectContent>,
+  React.ComponentPropsWithoutRef<typeof SelectContent>
+>(({ className, ...props }, ref) => (
+  <SelectContent ref={ref} className={cn(className)} {...props} />
+));
+BrandSelectContent.displayName = "BrandSelectContent";
+
+const BrandSelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectItem>,
+  React.ComponentPropsWithoutRef<typeof SelectItem>
+>(({ className, ...props }, ref) => (
+  <SelectItem ref={ref} className={cn(className)} {...props} />
+));
+BrandSelectItem.displayName = "BrandSelectItem";
+
+const BrandSelectValue = SelectValue;
+
+const BrandSelect = Select as typeof Select & {
+  Trigger: typeof BrandSelectTrigger;
+  Content: typeof BrandSelectContent;
+  Item: typeof BrandSelectItem;
+  Value: typeof BrandSelectValue;
+};
+
+BrandSelect.Trigger = BrandSelectTrigger;
+BrandSelect.Content = BrandSelectContent;
+BrandSelect.Item = BrandSelectItem;
+BrandSelect.Value = BrandSelectValue;
+
+export { BrandSelect };

--- a/src/components/brand/BrandSlider.tsx
+++ b/src/components/brand/BrandSlider.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
+
+export interface BrandSliderProps
+  extends React.ComponentPropsWithoutRef<typeof Slider> {}
+
+export const BrandSlider = React.forwardRef<
+  React.ElementRef<typeof Slider>,
+  BrandSliderProps
+>(({ className, ...props }, ref) => (
+  <Slider ref={ref} className={cn("w-full", className)} {...props} />
+));
+BrandSlider.displayName = "BrandSlider";
+
+export default BrandSlider;

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,18 +1,74 @@
-import React from "react";
-import { cn } from "@/lib/utils";
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronsUpDown } from "lucide-react"
 
-const Select = React.forwardRef(({ className, children, ...props }, ref) => (
-  <select
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full rounded-md border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]",
+      "flex h-10 w-full items-center justify-between rounded-md border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)] disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     {...props}
   >
     {children}
-  </select>
-));
-Select.displayName = "Select";
+    <SelectPrimitive.Icon asChild>
+      <ChevronsUpDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 
-export { Select };
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[var(--border)] bg-[var(--panel)] text-[var(--text)] shadow-md animate-in fade-in-80",
+        position === "popper" && "translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.Viewport className="p-1">
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-[color:rgba(79,119,45,0.07)] focus:text-[var(--text)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemIndicator className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <Check className="h-4 w-4" />
+    </SelectPrimitive.ItemIndicator>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectValue = SelectPrimitive.Value
+
+export { Select, SelectTrigger, SelectContent, SelectItem, SelectValue }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,6 +1,0 @@
-import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs) {
-  return twMerge(clsx(inputs));
-}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add typed `cn` utility
- introduce Brand* adapters wrapping shadcn primitives
- migrate calculator controls to brand components and improve labels

## Testing
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689902d64b14832294c0d5076ae6aa55