### PR TITLE
feat: use shadcn tabs and accordion components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-select": "^1.2.2",
+        "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^1.2.1",
@@ -2564,6 +2565,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
+      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.2.2.tgz",
@@ -3097,6 +3129,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
+      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-select": "^1.2.2",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",

--- a/src/components/BreakdownAccordion.jsx
+++ b/src/components/BreakdownAccordion.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { formatCurrency } from '@/utils/format';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion';
 
 /**
  * Collapsible section with calculation details.
@@ -12,15 +18,21 @@ export default function BreakdownAccordion({
   currency,
 }) {
   return (
-    <details className="mt-2">
-      <summary className="cursor-pointer text-sm text-[var(--brand)]">Ver desglose</summary>
-      <div className="mt-2 text-sm space-y-1">
-        <div>Semanas del proyecto: {semanasProyecto.toFixed(2)}</div>
-        <div>Utilización asumida: {utilizacion}%</div>
-        <div>Fórmula A: {formatCurrency(precioA, currency)}</div>
-        <div>Fórmula B: {formatCurrency(precioB, currency)}</div>
-        <div>Overhead y margen ya contemplados en la tarifa anual.</div>
-      </div>
-    </details>
+    <Accordion type="single" collapsible className="mt-2">
+      <AccordionItem value="details">
+        <AccordionTrigger className="text-sm text-[var(--brand)]">
+          Ver desglose
+        </AccordionTrigger>
+        <AccordionContent>
+          <div className="mt-2 text-sm space-y-1">
+            <div>Semanas del proyecto: {semanasProyecto.toFixed(2)}</div>
+            <div>Utilización asumida: {utilizacion}%</div>
+            <div>Fórmula A: {formatCurrency(precioA, currency)}</div>
+            <div>Fórmula B: {formatCurrency(precioB, currency)}</div>
+            <div>Overhead y margen ya contemplados en la tarifa anual.</div>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }

--- a/src/components/ModeToggle.jsx
+++ b/src/components/ModeToggle.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 /**
  * Segmented control to switch between annual and project modes.
@@ -6,27 +7,11 @@ import React from 'react';
  */
 export default function ModeToggle({ mode, onChange }) {
   return (
-    <div role="group" aria-label="Modo de cálculo" className="flex rounded-md overflow-hidden border border-[var(--border)]">
-      <button
-        type="button"
-        aria-pressed={mode === 'annual'}
-        onClick={() => onChange('annual')}
-        className={`px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] ${
-          mode === 'annual' ? 'bg-[var(--brand)] text-white' : 'bg-[var(--panel)]'
-        }`}
-      >
-        Modo Anual
-      </button>
-      <button
-        type="button"
-        aria-pressed={mode === 'project'}
-        onClick={() => onChange('project')}
-        className={`px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] ${
-          mode === 'project' ? 'bg-[var(--brand)] text-white' : 'bg-[var(--panel)]'
-        }`}
-      >
-        Modo Proyecto
-      </button>
-    </div>
+    <Tabs value={mode} onValueChange={onChange} className="w-full max-w-xs">
+      <TabsList className="grid w-full grid-cols-2">
+        <TabsTrigger value="annual">Modo Anual</TabsTrigger>
+        <TabsTrigger value="project">Modo Proyecto</TabsTrigger>
+      </TabsList>
+    </Tabs>
   );
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-md bg-[var(--panel)] p-1 text-[var(--muted)]",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-[var(--text)]",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- replace details element with shadcn accordion
- implement mode toggle using shadcn tabs
- add tabs ui component and dependency

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899666538d48322bc903caab8666556