### PR TITLE
Align project mode UI with brand styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -572,7 +572,7 @@ export default function App() {
               </div>
               </BrandCard>
           </section>
-          {mode === 'project' && (
+        {mode === 'project' && (
             <section className="md:col-span-2">
               <ProjectControls
                 meses={mesesProyecto}
@@ -584,9 +584,20 @@ export default function App() {
                 roundingStep={roundingStep}
                 setRoundingStep={setRoundingStep}
               />
+              <ProjectResultCard
+                currency={currency}
+                tarifaHora={tarifaHora}
+                horasProyecto={projectHours.horasProyecto}
+                precioFinal={precioFinal}
+                tarifaEfectiva={tarifaEfectiva}
+                semanasProyecto={projectHours.semanasProyecto}
+                utilizacion={billablePct}
+                precioBaseA={projectHours.precioBase}
+                precioBaseB={projectProrate.precioBase}
+              />
             </section>
-          )}
-        </div>
+        )}
+      </div>
 
         {/* Right: Results */}
         <aside className="md:col-span-1">
@@ -715,19 +726,6 @@ export default function App() {
                 </div>
               </div>
             </div>
-            {mode === 'project' && (
-              <ProjectResultCard
-                currency={currency}
-                tarifaHora={tarifaHora}
-                horasProyecto={projectHours.horasProyecto}
-                precioFinal={precioFinal}
-                tarifaEfectiva={tarifaEfectiva}
-                semanasProyecto={projectHours.semanasProyecto}
-                utilizacion={billablePct}
-                precioBaseA={projectHours.precioBase}
-                precioBaseB={projectProrate.precioBase}
-              />
-            )}
           </BrandCard>
         </aside>
       </div>

--- a/src/components/ProjectControls.jsx
+++ b/src/components/ProjectControls.jsx
@@ -19,8 +19,8 @@ export default function ProjectControls({
   setRoundingStep,
 }) {
   return (
-    <BrandCard className="p-4 mt-4">
-      <h2 className="text-base font-semibold mb-3">Proyecto</h2>
+    <BrandCard className="mt-4">
+      <h2 className="text-lg font-bold mb-3">Proyecto</h2>
       <div className="space-y-4">
         <div>
           <Label htmlFor="meses">Duración del proyecto (meses)</Label>

--- a/src/components/ProjectResultCard.jsx
+++ b/src/components/ProjectResultCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import BreakdownAccordion from './BreakdownAccordion';
-import { BrandCardFooter } from '@/components/brand/BrandCard';
+import { BrandCard } from '@/components/brand/BrandCard';
 import { formatCurrency } from '@/utils/format';
 
 /**
@@ -18,8 +18,8 @@ export default function ProjectResultCard({
   precioBaseB,
 }) {
   return (
-    <BrandCardFooter className="mt-4 border-t" style={{ borderColor: 'var(--border)' }}>
-      <h2 className="text-base font-semibold mb-3">Resultado del proyecto</h2>
+    <BrandCard className="mt-4">
+      <h2 className="text-lg font-bold mb-3">Resultado del proyecto</h2>
       <div className="space-y-1 text-sm">
         <div>
           <strong>Precio mínimo recomendado:</strong> {formatCurrency(precioFinal, currency)}
@@ -44,6 +44,6 @@ export default function ProjectResultCard({
         precioB={precioBaseB}
         currency={currency}
       />
-    </BrandCardFooter>
+    </BrandCard>
   );
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-[var(--text)]",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-[var(--brand)] data-[state=active]:text-white",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Style tabs using brand colors for active state
- Restyle "Proyecto" controls and display project result in its own card below inputs
- Relocate project result card to form column for consistent layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68996c6a1674832298b921d1de0f530a