### PR TITLE
feat: add dark/light mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { BrandButton } from '@/components/brand/BrandButton';
 import { BrandCard } from '@/components/brand/BrandCard';
 import DevelopmentTimePanel from '@/components/DevelopmentTimePanel';
 import ModeToggle from '@/components/ModeToggle';
+import ThemeToggle from '@/components/ThemeToggle';
 import ProjectControls from '@/components/ProjectControls';
 import ProjectResultCard from '@/components/ProjectResultCard';
 
@@ -339,7 +340,7 @@ export default function App() {
     <div className="min-h-screen flex flex-col">
       {/* Header */}
       <header
-        className="p-5 border-b flex items-center"
+        className="p-5 border-b flex items-center justify-between"
         style={{
           borderColor: 'var(--border)',
           background: 'linear-gradient(180deg, rgba(124,92,255,0.12), transparent)',
@@ -351,6 +352,7 @@ export default function App() {
           </h1>
           <ModeToggle mode={mode} onChange={setMode} />
         </div>
+        <ThemeToggle />
       </header>
 
       <div className="flex-grow p-4">

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+/**
+ * Simple toggle to switch between light and dark colour schemes.
+ * The choice is persisted in localStorage and applied by toggling
+ * the `dark` class on the document root.
+ */
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') return 'light';
+    const stored = window.localStorage.getItem('theme');
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    window.localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle dark mode"
+      onClick={toggle}
+      className="p-2 rounded border"
+      style={{ borderColor: 'var(--border)' }}
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,7 +25,28 @@
     --ring: 92 45% 32%;
     --radius: 0.75rem;
   }
-
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 92 45% 32%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+    --radius: 0.75rem;
+  }
 }
 
 
@@ -50,6 +71,18 @@
   --warn: #e9c46a;
   /* light olive border */
   --border: #b7b7a4;
+}
+
+.dark {
+  --bg: #1a1d1a;
+  --panel: rgba(32, 32, 32, 0.8);
+  --muted: #b7b7a4;
+  --text: #f1f5f2;
+  --brand: #4f772d;
+  --good: #588157;
+  --bad: #bc4749;
+  --warn: #e9c46a;
+  --border: #2e2e2e;
 }
 
 * {


### PR DESCRIPTION
## Summary
- add ThemeToggle component with persisted preference
- include dark theme palette and base variables
- integrate theme switcher into header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68997703fdac8322976e9ab6727ea854