### PR TITLE
feat: switch currency conversion to frequently-updated open-source API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Web-based calculator for determining hourly rates and project budgets for UI/UX 
 - Project scope and hours mix calculation
 - Client type and complexity adjusters
 - Support for both freelance and retainer engagement models
-- Real-time currency conversion with up-to-date exchange rates
+- Currency conversion with regularly updated exchange rates (via Fawaz Ahmed Currency API)
 - Export functionality for saving calculations (JSON and PDF)
 - Responsive design for all devices
 - Accessibility improvements with ARIA attributes

--- a/docs/currency-audit.md
+++ b/docs/currency-audit.md
@@ -1,0 +1,25 @@
+# Currency Data Audit
+
+## Current implementation status
+
+The app is **not** using a local or hosted database for currency rates.
+
+It now calls the Fawaz Ahmed Currency API directly from the frontend (`fetchRates` in `src/services/currency.js`), requesting:
+
+- `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd.json`
+
+This source is open source and frequently refreshed, but still **not true realtime/tick-level FX**.
+
+## Selected open-source source
+
+- **Fawaz Ahmed Currency API**
+- Repo: `https://github.com/fawazahmed0/currency-api`
+
+Reasons for selection:
+
+- Open-source and public repo.
+- Designed for free/public consumption.
+- Commonly used for lightweight frontend conversion use cases.
+- Provides broad currency coverage and regularly refreshed published data.
+
+> Note: if you need strict financial-grade realtime rates (seconds-level), you usually need a paid market data provider (not purely open-source-only).

--- a/src/services/currency.js
+++ b/src/services/currency.js
@@ -1,25 +1,53 @@
 /**
- * Service to fetch currency exchange rates from Frankfurter API.
- * API Docs: https://www.frankfurter.app/docs/
+ * Service to fetch currency exchange rates from Fawaz Ahmed Currency API.
+ * Repo: https://github.com/fawazahmed0/currency-api
  */
 
-const API_URL = 'https://api.frankfurter.app';
+const API_URL = 'https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies';
+
+function normalizeRates(payload, base) {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const baseKey = base.toLowerCase();
+  const baseRates = payload[baseKey];
+  if (!baseRates || typeof baseRates !== 'object') return null;
+
+  return Object.entries(baseRates).reduce((acc, [code, value]) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      acc[code.toUpperCase()] = value;
+    }
+    return acc;
+  }, { [base.toUpperCase()]: 1 });
+}
 
 /**
  * Fetch latest exchange rates for a base currency.
  * @param {string} base - Base currency code (e.g., 'USD')
- * @returns {Promise<Object>} - Object containing rates (e.g., { EUR: 0.85, ... })
+ * @returns {Promise<Object|null>} - Object containing rates (e.g., { EUR: 0.85, ... })
  */
 export async function fetchRates(base = 'USD') {
-    try {
-        const response = await fetch(`${API_URL}/latest?from=${base}`);
-        if (!response.ok) {
-            throw new Error(`Failed to fetch rates: ${response.statusText}`);
-        }
-        const data = await response.json();
-        return data.rates;
-    } catch (error) {
-        console.error('Currency fetch error:', error);
-        return null;
+  try {
+    const normalizedBase = base.toLowerCase();
+    const response = await fetch(`${API_URL}/${normalizedBase}.json`, {
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch rates: ${response.status} ${response.statusText}`);
     }
+
+    const data = await response.json();
+    const rates = normalizeRates(data, base);
+
+    if (!rates) {
+      throw new Error('Unexpected currency API response format');
+    }
+
+    return rates;
+  } catch (error) {
+    console.error('Currency fetch error:', error);
+    return null;
+  }
 }
+
+export { normalizeRates };

--- a/src/services/currency.test.js
+++ b/src/services/currency.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchRates, normalizeRates } from './currency.js';
+
+test('normalizeRates converts source keys to uppercase and includes base=1', () => {
+  const payload = {
+    date: '2026-01-01',
+    usd: {
+      eur: 0.91,
+      ars: 1099.22,
+      usd: 1,
+      note: 'ignore',
+    },
+  };
+
+  const rates = normalizeRates(payload, 'USD');
+
+  assert.equal(rates.USD, 1);
+  assert.equal(rates.EUR, 0.91);
+  assert.equal(rates.ARS, 1099.22);
+  assert.equal(rates.NOTE, undefined);
+});
+
+test('fetchRates returns normalized rates for selected base', async (t) => {
+  const originalFetch = global.fetch;
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      date: '2026-01-01',
+      usd: { eur: 0.9, gbp: 0.78 },
+    }),
+  });
+
+  const rates = await fetchRates('USD');
+
+  assert.deepEqual(rates, {
+    USD: 1,
+    EUR: 0.9,
+    GBP: 0.78,
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve currency rate freshness by switching from the Frankfurter endpoint to a widely used open-source provider that is frequently refreshed.
- Keep the UI conversion logic working with an API that provides broad currency coverage and simple CDN access for frontend apps.

### Description
- Replaced Frankfurter usage with the Fawaz Ahmed Currency API via the jsDelivr CDN in `src/services/currency.js` and changed `fetchRates` to request `https://.../v1/currencies/{base}.json`.
- Added `normalizeRates` to convert the API payload into uppercase ISO currency keys and include the base currency as `1`, and exported it from the module.
- Updated documentation references in `README.md` and added `docs/currency-audit.md` describing the selected open-source source and the request URL.
- Added unit tests in `src/services/currency.test.js` that validate `normalizeRates` behavior and `fetchRates` normalization with a mocked `fetch` response.

### Testing
- Ran the test suite with `npm test` and all tests passed: 4 tests total (including the new `normalizeRates` and `fetchRates` tests).
- Tests executed: unit tests for `normalizeRates` conversion and `fetchRates` normalization with mocked `fetch`, which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968bbbe2308322a0a7bcf99ea34c3b)